### PR TITLE
Fix: Unify bbdoc comments / doc-paths and add SavePixmapQoi()

### DIFF
--- a/bmp.mod/bmp.bmx
+++ b/bmp.mod/bmp.bmx
@@ -1,9 +1,8 @@
 SuperStrict
 
 Rem
-bbdoc: Image/BMP loader
-about:
-The BMP loader module provides the ability to load BMP format #pixmaps.
+bbdoc: Image/BMP Loader
+about: The BMP loader module provides the ability to load BMP format #pixmaps.
 End Rem
 Module Image.BMP
 

--- a/cms.mod/cms.bmx
+++ b/cms.mod/cms.bmx
@@ -17,7 +17,10 @@
 ' 3. This notice may not be removed or altered from any source distribution.
 ' 
 SuperStrict
-
+Rem
+bbdoc: Image/CMS Loader
+about: The CMS loader module provides the ability to load CMS format #pixmaps.
+End Rem
 Module Image.CMS
 
 

--- a/gif.mod/gif.bmx
+++ b/gif.mod/gif.bmx
@@ -19,9 +19,8 @@
 SuperStrict
 
 Rem
-bbdoc: Image/GIF loader
-about:
-The GIF loader module provides the ability to load GIF format #pixmaps.
+bbdoc: Image/GIF Loader
+about: The GIF loader module provides the ability to load GIF format #pixmaps.
 End Rem
 Module Image.GIF
 

--- a/ilbm.mod/ilbm.bmx
+++ b/ilbm.mod/ilbm.bmx
@@ -21,9 +21,8 @@
 SuperStrict
 
 Rem
-bbdoc: Image/ILBM loader
-about:
-The ILBM loader module provides the ability to load ILBM format #pixmaps.
+bbdoc: Image/ILBM Loader
+about: The ILBM loader module provides the ability to load ILBM format #pixmaps.
 End Rem
 Module Image.ILBM
 

--- a/jpeg2000.mod/jpeg2000.bmx
+++ b/jpeg2000.mod/jpeg2000.bmx
@@ -24,9 +24,8 @@
 SuperStrict
 
 Rem
-bbdoc: Graphics/JPEG 2000 loader
-about:
-The JPEG2000 loader module provides the ability to load JPEG 2000 format #pixmaps.
+bbdoc: Image/JPEG 2000 Loader
+about: The JPEG2000 loader module provides the ability to load JPEG 2000 format #pixmaps.
 End Rem
 Module Image.JPEG2000
 

--- a/jpg.mod/jpg.bmx
+++ b/jpg.mod/jpg.bmx
@@ -23,9 +23,8 @@
 SuperStrict
 
 Rem
-bbdoc: Graphics/JPG loader
-about:
-The JPG loader module provides the ability to load JPG format #pixmaps.
+bbdoc: Image/JPG Loader
+about: The JPG loader module provides the ability to load JPG format #pixmaps.
 End Rem
 Module Image.JPG
 

--- a/jxl.mod/jxl.bmx
+++ b/jxl.mod/jxl.bmx
@@ -27,9 +27,8 @@
 SuperStrict
 
 Rem
-bbdoc: Image/JXL loader
-about:
-The JXL loader module provides the ability to load JXL format #pixmaps.
+bbdoc: Image/JXL Loader
+about: The JXL loader module provides the ability to load JXL format #pixmaps.
 End Rem
 Module Image.JXL
 

--- a/jxlwriter.mod/jxlwriter.bmx
+++ b/jxlwriter.mod/jxlwriter.bmx
@@ -27,9 +27,8 @@
 SuperStrict
 
 Rem
-bbdoc: Image/JXL writer
-about:
-The JXL writer module provides the ability to save JXL format #pixmaps.
+bbdoc: Image/JXL Writer
+about: The JXL writer module provides the ability to save JXL format #pixmaps.
 End Rem
 Module Image.JXLWriter
 

--- a/pcx.mod/pcx.bmx
+++ b/pcx.mod/pcx.bmx
@@ -19,9 +19,8 @@
 SuperStrict
 
 Rem
-bbdoc: Image/PCX loader
-about:
-The PCX loader module provides the ability to load PCX format #pixmaps.
+bbdoc: Image/PCX Loader
+about: The PCX loader module provides the ability to load PCX format #pixmaps.
 End Rem
 Module Image.PCX
 

--- a/pic.mod/pic.bmx
+++ b/pic.mod/pic.bmx
@@ -19,9 +19,8 @@
 SuperStrict
 
 Rem
-bbdoc: Image/PIC loader
-about:
-The PIC loader module provides the ability to load PIC format #pixmaps.
+bbdoc: Image/PIC Loader
+about: The PIC loader module provides the ability to load PIC format #pixmaps.
 End Rem
 Module Image.PIC
 

--- a/png.mod/png.bmx
+++ b/png.mod/png.bmx
@@ -23,8 +23,8 @@
 SuperStrict
 
 Rem
-bbdoc: Image/PNG load/save
-about: The PNG loader module provides the ability to load PNG format #pixmaps.
+bbdoc: Image/PNG Loader and Writer
+about: The PNG loader module provides the ability to load and write PNG format #pixmaps.
 End Rem
 Module Image.PNG
 

--- a/pnm.mod/pnm.bmx
+++ b/pnm.mod/pnm.bmx
@@ -19,9 +19,8 @@
 SuperStrict
 
 Rem
-bbdoc: Image/PNM loader
-about:
-The PNM loader module provides the ability to load PNM format #pixmaps.
+bbdoc: Image/PNM Loader
+about: The PNM loader module provides the ability to load PNM format #pixmaps.
 End Rem
 Module Image.PNM
 

--- a/qoi.mod/qoi.bmx
+++ b/qoi.mod/qoi.bmx
@@ -21,7 +21,8 @@
 SuperStrict
 
 Rem
-bbdoc: Qoi Image Loading/Saving
+bbdoc: Image/Qoi Loader and Writer
+about: The Qoi module provides the ability to load and save Qoi format #pixmaps.
 End Rem
 Module Image.Qoi
 
@@ -84,8 +85,9 @@ Type TQoiImage
 
 	Rem
 	bbdoc: Saves pixmap to a #TStream as Qoi image.
+	about: Returns #True if the #TPixmap was successfully written to the stream.
 	End Rem
-	Function Save(stream:TStream, pix:TPixmap)
+	Function Save:Int(stream:TStream, pix:TPixmap)
 		Local desc:SQoiDesc
 		desc.width = pix.width
 		desc.height = pix.height
@@ -102,6 +104,7 @@ Type TQoiImage
 				desc.channels = 4
 		End Select
 
+		Local result:Int
 		Local data:Byte Ptr
 		Try
 			Local outLen:Int
@@ -110,11 +113,33 @@ Type TQoiImage
 		Finally
 			If data Then
 				free_(data)
+				If outLen > 0 Then
+					result = True
+				End If
 			End If
 		End Try
-		
+		Return result
 	End Function
 End Type
+
+
+Rem
+bbdoc: Save a Pixmap in Qoi format
+about:
+#SavePixmapQoi saves @pixmap to @url in Qoi format. If successful, #SavePixmapPNG returns
+True, otherwise False.
+End Rem
+Function SavePixmapQoi:Int( pixmap:TPixmap, url:Object )
+	Local qoi_stream:TStream = WriteStream( url )
+	If Not qoi_stream Return False
+	
+	Local result:Int = TQoiImage.Save(qoi_stream, pixmap)
+		
+	qoi_stream.Close()
+	qoi_stream=Null
+		
+	Return result
+End Function
 
 Private
 

--- a/raw.mod/raw.bmx
+++ b/raw.mod/raw.bmx
@@ -21,6 +21,10 @@
 '
 SuperStrict
 
+Rem
+bbdoc: Image/RAW Loader
+about: The RAW loader module provides the ability to load RAW format #pixmaps.
+End Rem
 Module Image.Raw
 
 ModuleInfo "Version: 1.00"

--- a/stb.mod/stb.bmx
+++ b/stb.mod/stb.bmx
@@ -17,7 +17,10 @@
 ' 3. This notice may not be removed or altered from any source distribution.
 ' 
 SuperStrict
-
+Rem
+bbdoc: Image/STB Loader
+about: The STB loader module provides the ability to load STB format #pixmaps.
+End Rem
 Module Image.STB
 
 ModuleInfo "Version: 1.06"

--- a/svg.mod/svg.bmx
+++ b/svg.mod/svg.bmx
@@ -21,9 +21,8 @@
 SuperStrict
 
 Rem
-bbdoc: Image/SVG loader
-about:
-The SVG loader module provides the ability to load SVG format #pixmaps.
+bbdoc: Image/SVG Loader
+about: The SVG loader module provides the ability to load SVG format #pixmaps.
 End Rem
 Module Image.SVG
 

--- a/tga.mod/tga.bmx
+++ b/tga.mod/tga.bmx
@@ -1,9 +1,8 @@
 SuperStrict
 
 Rem
-bbdoc: Image/TGA loader
-about:
-The TGA loader module provides the ability to load TGA format #pixmaps.
+bbdoc: Image/TGA Loader
+about: The TGA loader module provides the ability to load TGA format #pixmaps.
 End Rem
 Module Image.TGA
 

--- a/tiff.mod/tiff.bmx
+++ b/tiff.mod/tiff.bmx
@@ -22,9 +22,8 @@
 SuperStrict
 
 Rem
-bbdoc: Image/TIFF loader
-about:
-The TIFF loader module provides the ability to load TIFF format #pixmaps.
+bbdoc: Image/TIFF Loader
+about: The TIFF loader module provides the ability to load TIFF format #pixmaps.
 End Rem
 Module Image.Tiff
 

--- a/webp.mod/webp.bmx
+++ b/webp.mod/webp.bmx
@@ -20,7 +20,6 @@
 '    distribution.
 '
 SuperStrict
-
 Rem
 bbdoc: Image/WebP Loader
 about: The WebP loader module provides the ability to load WebP format #pixmaps.

--- a/yuv.mod/yuv.bmx
+++ b/yuv.mod/yuv.bmx
@@ -27,7 +27,7 @@
 SuperStrict
 
 Rem
-bbdoc: Image/YUV
+bbdoc: Image/YUV-ARGB Converter
 about: Provides functions to convert between YUV and RGB.
 End Rem
 Module Image.yuv


### PR DESCRIPTION
Unifies bbdoc comments so that makedocs groups them correctly.
Adds `SavePixmapQoi()` which allows saving a pixmap as png (similar to what `SavePixmapPNG()` does)